### PR TITLE
feat: Add multiple bindings configs permission in pixel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add permission to config multiple bindings
+
 ## [0.1.0] - 2019-11-22

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
   "settingsSchema": {
     "title": "Bing uet Options",
     "type": "object",
+    "bindingBounded": true,
     "properties": {
       "bingId": {
         "title": "Bing Key",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add permission to use multiple bindings inside bing pixel app

#### What problem is this solving?

Use different settings in different bindings

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
